### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
         ruby_version: ["2.7", "3.0", "3.1", "3.2"]
         redmine_version: [4.2-stable, 5.0-stable, 5.1-stable, master]
         exclude:
+          - ruby_version: "2.7"
+            redmine_version: master
           - ruby_version: "3.0"
             redmine_version: 4.2-stable
           - ruby_version: "3.1"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,7 @@
+
+# For backward compatibility with Redmine < 6.
+# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine >= 6.
+# ref: https://www.redmine.org/issues/38975
+unless defined?(ApplicationRecord)
+  ApplicationRecord = ActiveRecord::Base
+end

--- a/app/models/wiki_extensions_comment.rb
+++ b/app/models/wiki_extensions_comment.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsComment < ActiveRecord::Base
+class WikiExtensionsComment < ApplicationRecord
   belongs_to :user
   belongs_to :wiki_page
   validates_presence_of :comment, :wiki_page_id, :user_id

--- a/app/models/wiki_extensions_count.rb
+++ b/app/models/wiki_extensions_count.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsCount < ActiveRecord::Base
+class WikiExtensionsCount < ApplicationRecord
   belongs_to :project
   belongs_to :page, :foreign_key => :page_id, :class_name => 'WikiPage'
   validates_presence_of :project

--- a/app/models/wiki_extensions_menu.rb
+++ b/app/models/wiki_extensions_menu.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsMenu < ActiveRecord::Base
+class WikiExtensionsMenu < ApplicationRecord
   include Redmine::SafeAttributes
   belongs_to :project
   validates_presence_of :project_id

--- a/app/models/wiki_extensions_setting.rb
+++ b/app/models/wiki_extensions_setting.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsSetting < ActiveRecord::Base
+class WikiExtensionsSetting < ApplicationRecord
   belongs_to :project
   #attr_accessible :auto_preview_enabled, :tag_disabled
 

--- a/app/models/wiki_extensions_tag.rb
+++ b/app/models/wiki_extensions_tag.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsTag < ActiveRecord::Base
+class WikiExtensionsTag < ApplicationRecord
   #attr_accessible :name, :project_id
   validates_presence_of :name, :project_id
   validates_uniqueness_of :name, :scope => :project_id

--- a/app/models/wiki_extensions_tag_relation.rb
+++ b/app/models/wiki_extensions_tag_relation.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsTagRelation < ActiveRecord::Base
+class WikiExtensionsTagRelation < ApplicationRecord
   belongs_to :wiki_page
   belongs_to :tag, :class_name => 'WikiExtensionsTag', :foreign_key => :tag_id
   validates_presence_of :wiki_page_id, :tag_id

--- a/app/models/wiki_extensions_vote.rb
+++ b/app/models/wiki_extensions_vote.rb
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-class WikiExtensionsVote < ActiveRecord::Base
+class WikiExtensionsVote < ApplicationRecord
   validates_presence_of :target_class_name, :target_id, :keystr, :count
   validates_uniqueness_of :keystr, :scope => [:target_class_name, :target_id]
 


### PR DESCRIPTION
FIx follwoing points about CI
- Redmine master doesn't support Ruby version2.7
- Use the AppicationRecord as a base model