### PR TITLE
Extend `child_pages_count` macro like `child_pages` macro

### DIFF
--- a/lib/wiki_extensions_child_pages_count_macro.rb
+++ b/lib/wiki_extensions_child_pages_count_macro.rb
@@ -27,7 +27,7 @@ module WikiExtensionsChildPagesCountMacro
     desc "Displays the number of child pages. With no argument, it displays the number of child pages from current wiki page. Examples:\n\n" +
          "{{child_pages_count}} -- can be used from a wiki page only\n" +
          "{{child_pages_count(depth=2)}} -- display the number of 2 levels nesting pages only\n" +
-         "{{child_pages_count(Foo)}} -- display the number of all children pages form Foo"
+         "{{child_pages_count(Foo)}} -- display the number of all children pages from Foo"
     macro :child_pages_count do |obj, args|
       args, options = extract_macro_options(args, :parent, :depth)
       options[:depth] = options[:depth].to_i if options[:depth].present?

--- a/lib/wiki_extensions_child_pages_count_macro.rb
+++ b/lib/wiki_extensions_child_pages_count_macro.rb
@@ -1,3 +1,23 @@
+# frozen_string_literal: true
+
+# Redmine - project management software
+# Copyright (C) 2006-  Jean-Philippe Lang
+# Copyright (C) 2024-  Kodama Takuya <otegami@clear-code.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 require 'redmine'
 
 module WikiExtensionsChildPagesCountMacro

--- a/lib/wiki_extensions_child_pages_count_macro.rb
+++ b/lib/wiki_extensions_child_pages_count_macro.rb
@@ -22,6 +22,8 @@ require 'redmine'
 
 module WikiExtensionsChildPagesCountMacro
   Redmine::WikiFormatting::Macros.register do
+    # Adapted from the core logic of `child_pages` macro from Redmine's implementation.
+    # ref: https://github.com/redmine/redmine/blob/c3fe22476231adff5f6fef2e1692be8024dd0c44/lib/redmine/wiki_formatting/macros.rb#L193-L214
     desc "Displays the number of child pages. With no argument, it displays the number of child pages from current wiki page. Examples:\n\n" +
          "{{child_pages_count}} -- can be used from a wiki page only\n" +
          "{{child_pages_count(depth=2)}} -- display the number of 2 levels nesting pages only\n" +

--- a/lib/wiki_extensions_child_pages_count_macro.rb
+++ b/lib/wiki_extensions_child_pages_count_macro.rb
@@ -29,7 +29,7 @@ module WikiExtensionsChildPagesCountMacro
          "{{child_pages_count(depth=2)}} -- display the number of 2 levels nesting pages only\n" +
          "{{child_pages_count(Foo)}} -- display the number of all children pages from Foo"
     macro :child_pages_count do |obj, args|
-      args, options = extract_macro_options(args, :parent, :depth)
+      args, options = extract_macro_options(args, :depth)
       options[:depth] = options[:depth].to_i if options[:depth].present?
 
       page = nil

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
-  include ApplicationHelper
   include ERB::Util
 
   fixtures :projects, :wikis, :wiki_pages, :wiki_contents, :wiki_content_versions, :issues,

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -23,6 +23,12 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content.versions.first)
   end
 
+  def test_macro_child_pages_with_depth_option
+    @project = Project.find(1)
+    wiki_page = WikiPage.find(2)
+    assert_equal '<p>2</p>', textilizable('{{child_pages_count(depth=1)}}', object: wiki_page.content)
+  end
+
   def test_child_pages_count_in_issue_page
     @project = Project.find(1)
     macro_error_message = <<-MESSAGE.gsub("\n", "")

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -12,31 +12,31 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
     @project = nil
   end
 
-  def test_child_pages_count_in_wiki_content
+  def test_in_wiki_content
     @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content)
   end
 
-  def test_child_pages_count_in_wiki_content_version
+  def test_in_wiki_content_version
     @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content.versions.first)
   end
 
-  def test_child_pages_count_with_child_page
+  def test_with_child_page
     @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>1</p>', textilizable('{{child_pages_count(Child_1)}}', object: wiki_page.content)
   end
 
-  def test_child_pages_count_with_depth_option
+  def test_with_depth_option
     @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>2</p>', textilizable('{{child_pages_count(depth=1)}}', object: wiki_page.content)
   end
 
-  def test_child_pages_count_in_issue_page
+  def test_in_issue_page
     @project = Project.find(1)
     macro_error_message = <<-MESSAGE.gsub("\n", "")
 <p>
@@ -49,7 +49,7 @@ Error executing the <strong>child_pages_count</strong> macro
     assert_equal macro_error_message, textilizable('{{child_pages_count}}', object: Issue.first)
   end
 
-  def test_child_pages_count_in_wiki_without_permissions
+  def test_without_permissions
     @project = Project.find(1)
     another_project_wiki = WikiPage.find(3)
     macro_error_message = <<~MESSAGE.gsub("\n", "")

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -23,7 +23,13 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content.versions.first)
   end
 
-  def test_macro_child_pages_with_depth_option
+  def test_child_pages_count_with_child_page_in_wiki_content
+    @project = Project.find(1)
+    wiki_page = WikiPage.find(2)
+    assert_equal '<p>1</p>', textilizable('{{child_pages_count(Child_1)}}', object: wiki_page.content)
+  end
+
+  def test_child_pages_count_with_depth_option
     @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>2</p>', textilizable('{{child_pages_count(depth=1)}}', object: wiki_page.content)

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -4,19 +4,27 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
   include ApplicationHelper
   include ERB::Util
 
-  fixtures :projects, :wikis, :wiki_pages, :wiki_contents, :wiki_content_versions, :issues
+  fixtures :projects, :wikis, :wiki_pages, :wiki_contents, :wiki_content_versions, :issues,
+           :roles, :enabled_modules, :users
+
+  def teardown
+    @project = nil
+  end
 
   def test_child_pages_count_in_wiki_content
+    @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content)
   end
 
   def test_child_pages_count_in_wiki_content_version
+    @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content.versions.first)
   end
 
   def test_child_pages_count_in_issue_page
+    @project = Project.find(1)
     macro_error_message = <<-MESSAGE.gsub("\n", "")
 <p>
 <div class="flash error">

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -42,8 +42,8 @@ Error executing the <strong>child_pages_count</strong> macro
     assert_equal macro_error_message, textilizable('{{child_pages_count}}', object: Issue.first)
   end
 
-  def test_without_permissions
-    another_project_wiki = WikiPage.find(3)
+  def test_in_another_porject_wiki_without_permissions
+    another_project_wiki = Project.find(2).wiki.pages.first
     macro_error_message = <<~MESSAGE.gsub("\n", "")
 <p>
 <div class="flash error">

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -9,35 +9,30 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
 
   def setup
     super
-    @project = nil
+    @project = Project.find(1)
   end
 
   def test_in_wiki_content
-    @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content)
   end
 
   def test_in_wiki_content_version
-    @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content.versions.first)
   end
 
   def test_with_child_page
-    @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>1</p>', textilizable('{{child_pages_count(Child_1)}}', object: wiki_page.content)
   end
 
   def test_with_depth_option
-    @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>2</p>', textilizable('{{child_pages_count(depth=1)}}', object: wiki_page.content)
   end
 
   def test_in_issue_page
-    @project = Project.find(1)
     macro_error_message = <<-MESSAGE.gsub("\n", "")
 <p>
 <div class="flash error">
@@ -50,7 +45,6 @@ Error executing the <strong>child_pages_count</strong> macro
   end
 
   def test_without_permissions
-    @project = Project.find(1)
     another_project_wiki = WikiPage.find(3)
     macro_error_message = <<~MESSAGE.gsub("\n", "")
 <p>

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -24,7 +24,7 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
     assert_equal '<p>3</p>', textilizable('{{child_pages_count}}', object: wiki_page.content.versions.first)
   end
 
-  def test_child_pages_count_with_child_page_in_wiki_content
+  def test_child_pages_count_with_child_page
     @project = Project.find(1)
     wiki_page = WikiPage.find(2)
     assert_equal '<p>1</p>', textilizable('{{child_pages_count(Child_1)}}', object: wiki_page.content)

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -23,8 +23,7 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
   end
 
   def test_with_child_page
-    wiki_page = WikiPage.find(2)
-    assert_equal '<p>1</p>', textilizable('{{child_pages_count(Child_1)}}', object: wiki_page.content)
+    assert_equal '<p>1</p>', textilizable('{{child_pages_count(Child_1)}}')
   end
 
   def test_with_depth_option

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -7,7 +7,8 @@ class WikiExtensionsChildPagesCountTest < Redmine::HelperTest
   fixtures :projects, :wikis, :wiki_pages, :wiki_contents, :wiki_content_versions, :issues,
            :roles, :enabled_modules, :users
 
-  def teardown
+  def setup
+    super
     @project = nil
   end
 

--- a/test/unit/wiki_extensions_child_pages_count_test.rb
+++ b/test/unit/wiki_extensions_child_pages_count_test.rb
@@ -47,4 +47,17 @@ Error executing the <strong>child_pages_count</strong> macro
     MESSAGE
     assert_equal macro_error_message, textilizable('{{child_pages_count}}', object: Issue.first)
   end
+
+  def test_child_pages_count_in_wiki_without_permissions
+    @project = Project.find(1)
+    another_project_wiki = WikiPage.find(3)
+    macro_error_message = <<~MESSAGE.gsub("\n", "")
+<p>
+<div class="flash error">
+Error executing the <strong>child_pages_count</strong> macro (Page not found)
+</div>
+</p>
+    MESSAGE
+    assert_equal macro_error_message, textilizable('{{child_pages_count}}', object: another_project_wiki.content)
+  end
 end


### PR DESCRIPTION
I added the same API as `child_pages`macro in Redmine.
I didn't add the only `parent` option because there is no use-case users want to create the link to the number of child pages.

ref: `{{child_pages}}macro`

https://github.com/redmine/redmine/blob/c3fe22476231adff5f6fef2e1692be8024dd0c44/lib/redmine/wiki_formatting/macros.rb#L193-L214