### PR TITLE
Add author option to child_pages_count macro

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,4 +24,5 @@ en:
   wiki_extensions_new_wiki_page: 'New page'
   field_tag_disabled: 'Disable tagging function'
 
+  error_user_not_found: User not found
   error_child_pages_count_macro: 'This {{child_pages_count}} macro can be called from Wiki pages only'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,4 +24,5 @@ ja:
   wiki_extensions_new_wiki_page: 新規ページ
   field_tag_disabled: タグを利用しない
 
+  user_not_found: ユーザーが見つかりません
   error_child_pages_count_macro: '{{child_pages_count}}マクロは、Wikiページ以外から呼び出すせません。'

--- a/lib/wiki_extensions_child_pages_count_macro.rb
+++ b/lib/wiki_extensions_child_pages_count_macro.rb
@@ -21,15 +21,19 @@
 require 'redmine'
 
 module WikiExtensionsChildPagesCountMacro
+  CURRENT_USER = 'current'
+
   Redmine::WikiFormatting::Macros.register do
     # Adapted from the core logic of `child_pages` macro from Redmine's implementation.
     # ref: https://github.com/redmine/redmine/blob/c3fe22476231adff5f6fef2e1692be8024dd0c44/lib/redmine/wiki_formatting/macros.rb#L193-L214
     desc "Displays the number of child pages. With no argument, it displays the number of child pages from current wiki page. Examples:\n\n" +
          "{{child_pages_count}} -- can be used from a wiki page only\n" +
          "{{child_pages_count(depth=2)}} -- display the number of 2 levels nesting pages only\n" +
-         "{{child_pages_count(Foo)}} -- display the number of all children pages from Foo"
+         "{{child_pages_count(Foo)}} -- display the number of all children pages from Foo\n" +
+         "{{child_pages_count(author=current)}} -- display the number of all children pages authored by current user\n" +
+         "{{child_pages_count(author=alice)}} -- display the number of all children pages authored by login-name user"
     macro :child_pages_count do |obj, args|
-      args, options = extract_macro_options(args, :depth)
+      args, options = extract_macro_options(args, :depth, :author)
       options[:depth] = options[:depth].to_i if options[:depth].present?
 
       page = nil
@@ -43,6 +47,14 @@ module WikiExtensionsChildPagesCountMacro
       raise t(:error_page_not_found) if page.nil? || !User.current.allowed_to?(:view_wiki_pages, page.wiki.project)
 
       child_pages = page.descendants(options[:depth])
+
+      if options[:author].present?
+        user = options[:author] == CURRENT_USER ? User.current : User.find_by_login(options[:author])
+        raise t(:error_user_not_found) if user.nil?
+
+        child_pages = child_pages.select { |page| page.content.author_id == user.id }
+      end
+
       child_pages.size.to_s
     end
   end


### PR DESCRIPTION
Adding functionality to count the number of children pages created by a specified user under a parent Wiki page.
- `{{child_pages_count(author=current)}}`: Count pages created by current user
- `{{child_pages_count(author=alice)}}`: Count pages created by alice